### PR TITLE
Allow customizing the clusterGroupChartVersion

### DIFF
--- a/templates/pattern.yaml
+++ b/templates/pattern.yaml
@@ -20,6 +20,9 @@ spec:
 {{- if .Values.main.multiSourceConfig.helmRepoUrl }}
     helmRepoUrl: {{ .Values.main.multiSourceConfig.helmRepoUrl }}
 {{- end }} {{/* if .Values.main.multiSourceConfig.helmRepoUrl */}}
+{{- if .Values.main.multiSourceConfig.clusterGroupChartVersion }}
+    clusterGroupChartVersion: {{ .Values.main.multiSourceConfig.clusterGroupChartVersion }}
+{{- end }} {{/* if .Values.main.multiSourceConfig.clusterGroupChartVersion */}}
 {{- if .Values.main.analyticsUUID }}
   analyticsUUID: {{ .Values.main.analyticsUUID }}
 {{- end }} {{/* if .Values.main.analyticsUUID */}}

--- a/values.yaml
+++ b/values.yaml
@@ -18,6 +18,7 @@ main:
   multiSourceConfig:
     enabled: false
     # helmRepoUrl: registry.internal.network/helm
+    # clusterGroupChartVersion: 0.8.*
 
   # String to enable certain experimental capabilities in the operator and the
   # framework. Not needed unless you know exactly what you're doing.


### PR DESCRIPTION
❯ helm template . --show-only "templates/pattern.yaml"
---
apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
kind: Pattern
metadata:
  name: release-name
  namespace: openshift-operators
spec:
  clusterGroupName: default
  gitSpec:
    targetRepo: https://github.com/pattern-clone/mypattern
    targetRevision: main
  multiSourceConfig:
    enabled: false

❯ helm template .  --show-only "templates/pattern.yaml"  --set main.multiSourceConfig.clusterGroupChartVersion=0.9.\*
---
apiVersion: gitops.hybrid-cloud-patterns.io/v1alpha1
kind: Pattern
metadata:
  name: release-name
  namespace: openshift-operators
spec:
  clusterGroupName: default
  gitSpec:
    targetRepo: https://github.com/pattern-clone/mypattern
    targetRevision: main
  multiSourceConfig:
    enabled: false
    clusterGroupChartVersion: 0.9.*
