### PR TITLE
gitops 1.15 support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart to build and deploy a Cloud Pattern via the patterns o
 keywords:
 - pattern
 name: pattern-install
-version: 0.0.5
+version: 0.0.6
 home: https://github.com/validatedpatterns/pattern-install-chart
 maintainers:
   - name: Validated Patterns Team

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pattern-install
 
-![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square)
+![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square)
 
 A Helm chart to build and deploy a Cloud Pattern via the patterns operator
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This chart is used by the Validated Patterns installation script that can be fou
 | main.git.repoUpstreamURL | string | `nil` | Setting this field will make it so that an in-cluster gitea instance will be spawned. `repoURL` will be ignored and the pattern will be deployed using the in-gitea URL |
 | main.git.revision | string | `"main"` | The branch or Git reference to use to deploy the pattern |
 | main.gitops | object | depends on the individual settings | Settings related to the gitops operator |
-| main.gitops.channel | string | `"gitops-1.14"` | Default channel to install the gitops operator from |
+| main.gitops.channel | string | `"gitops-1.15"` | Default channel to install the gitops operator from |
 | main.gitops.operatorSource | string | `"redhat-operators"` | Source to be used to install the gitops operator from |
 | main.multiSourceConfig.clusterGroupChartVersion | string | `nil` | The clustergroup chart version to be used when deploying a pattern (defaults to 0.8.*) |
 | main.multiSourceConfig.enabled | bool | `false` | Enables a multisource configuration for the clustergroup chart |

--- a/tests/pattern_operator_configmap_test.yaml
+++ b/tests/pattern_operator_configmap_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: redhat-operators
       - equal:
           path: data["gitops.channel"]
-          value: gitops-1.14
+          value: gitops-1.15
 
   - it: Should set gitops.catalogSource
     set:

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ main:
   # @default -- depends on the individual settings
   gitops:
     # -- Default channel to install the gitops operator from
-    channel: "gitops-1.14"
+    channel: "gitops-1.15"
     # -- Source to be used to install the gitops operator from
     operatorSource: redhat-operators
 


### PR DESCRIPTION
- **Upgrade default gitops channel to gitops-1.15**
- **Update pattern-install chart to 0.0.6**
