### PR TITLE
Switch to gitops-1.18 channel by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This chart is used by the Validated Patterns installation script that can be fou
 | main.gitea.chartVersion | string | `"0.0.*"` | Chart version to install |
 | main.gitea.helmRepoUrl | string | `"https://charts.validatedpatterns.io/"` | Helm Repository URL for the gitea chart |
 | main.gitops | object | depends on the individual settings | Settings related to the gitops operator |
-| main.gitops.channel | string | `"gitops-1.17"` | Default channel to install the gitops operator from |
+| main.gitops.channel | string | `"gitops-1.18"` | Default channel to install the gitops operator from |
 | main.gitops.operatorSource | string | `"redhat-operators"` | Source to be used to install the gitops operator from |
 | main.multiSourceConfig.clusterGroupChartVersion | string | `nil` | The clustergroup chart version to be used when deploying a pattern (defaults to 0.8.*) |
 | main.multiSourceConfig.enabled | bool | `false` | Enables a multisource configuration for the clustergroup chart |

--- a/tests/pattern_operator_configmap_test.yaml
+++ b/tests/pattern_operator_configmap_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: redhat-operators
       - equal:
           path: data["gitops.channel"]
-          value: gitops-1.17
+          value: gitops-1.18
       - equal:
           path: data["gitea.chartName"]
           value: gitea

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ main:
   # @default -- depends on the individual settings
   gitops:
     # -- Default channel to install the gitops operator from
-    channel: "gitops-1.17"
+    channel: "gitops-1.18"
     # -- Source to be used to install the gitops operator from
     operatorSource: redhat-operators
 


### PR DESCRIPTION
Testd on mcg. Supported on all our needed ocp versions:
https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.18/html-single/release_notes/index
