### PR TITLE
Allow to skip subscription and operatorgroup creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This chart is used by the Validated Patterns installation script that can be fou
 | main.multiSourceConfig.helmRepoUrl | string | `nil` | The URL of the VP helm charts repository (defaults to https://charts.validatedpatterns.io) |
 | main.patternsOperator | object | depends on the individual settings | Settings related to the patterns operator installation |
 | main.patternsOperator.channel | string | `"fast"` | channel name to install the patterns operator from |
+| main.patternsOperator.enableSubscription | bool | `true` | Whether to create the Subscription (and Namespace/OperatorGroup) for the patterns operator. Set to false if the operator is already installed or managed externally. |
 | main.patternsOperator.installPlanApproval | string | `"Automatic"` | Installation plan approval of the patterns operator |
 | main.patternsOperator.source | string | `"community-operators"` | Source to be used to install the patterns operator from |
 | main.patternsOperator.sourceNamespace | string | `"openshift-marketplace"` | Source namespace to install the patterns operator from |

--- a/templates/subscription-namespace.yaml
+++ b/templates/subscription-namespace.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.main.patternsOperator.subscriptionNamespace "openshift-operators" }}
+{{- if and .Values.main.patternsOperator.enableSubscription (ne .Values.main.patternsOperator.subscriptionNamespace "openshift-operators") }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/templates/subscription.yaml
+++ b/templates/subscription.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.main.patternsOperator.enableSubscription }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -12,3 +13,4 @@ spec:
   {{- if .Values.main.patternsOperator.startingCSV }}
   startingCSV: {{ .Values.main.patternsOperator.startingCSV }}
   {{- end }}
+{{- end }}

--- a/tests/subscription_namespace_test.yaml
+++ b/tests/subscription_namespace_test.yaml
@@ -96,3 +96,60 @@ tests:
           path: metadata.name
           value: patterns-operator-group
         documentIndex: 1
+
+  - it: Should not create namespace or operatorgroup when patternsOperator is disabled with default namespace
+    template: templates/subscription-namespace.yaml
+    set:
+      main:
+        patternsOperator:
+          enableSubscription: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create namespace or operatorgroup when patternsOperator is disabled with custom namespace
+    template: templates/subscription-namespace.yaml
+    set:
+      main:
+        patternsOperator:
+          enableSubscription: false
+          subscriptionNamespace: custom-namespace
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create subscription when patternsOperator is disabled
+    template: templates/subscription.yaml
+    set:
+      main:
+        patternsOperator:
+          enableSubscription: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should still create pattern when patternsOperator is disabled
+    template: templates/pattern.yaml
+    release:
+      name: release-test
+    set:
+      main:
+        patternsOperator:
+          enableSubscription: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Pattern
+
+  - it: Should still create configmap when patternsOperator is disabled
+    template: templates/pattern-operator-configmap.yaml
+    set:
+      main:
+        patternsOperator:
+          enableSubscription: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap

--- a/tests/subscription_test.yaml
+++ b/tests/subscription_test.yaml
@@ -61,3 +61,28 @@ tests:
       - notExists:
           path: spec.startingCSV
 
+  - it: Should not create subscription when patternsOperator is disabled
+    set:
+      main:
+        patternsOperator:
+          enableSubscription: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create subscription when patternsOperator is explicitly enabled
+    set:
+      main:
+        patternsOperator:
+          enableSubscription: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Subscription
+      - containsDocument:
+          kind: Subscription
+          apiVersion: operators.coreos.com/v1alpha1
+          name: patterns-operator
+          namespace: openshift-operators
+

--- a/values.yaml
+++ b/values.yaml
@@ -52,6 +52,9 @@ main:
   # -- Settings related to the patterns operator installation
   # @default -- depends on the individual settings
   patternsOperator:
+    # -- Whether to create the Subscription (and Namespace/OperatorGroup) for the patterns operator.
+    # Set to false if the operator is already installed or managed externally.
+    enableSubscription: true
     # -- channel name to install the patterns operator from
     channel: fast
     # -- Source to be used to install the patterns operator from


### PR DESCRIPTION
This is useful when testing custom patterns-operator builds
so one can just use the patterns-operator that has already been
pushed onto the cluster.
