### PR TITLE
Add custom ArgoCD Yaml support

### DIFF
--- a/templates/pattern-operator-configmap.yaml
+++ b/templates/pattern-operator-configmap.yaml
@@ -17,6 +17,10 @@ data:
   gitops.argoRBAC: |
 {{ .Values.main.gitops.argoRBAC | indent 4 }}
   {{- end }}
+  {{- if .Values.main.gitops.customArgoYaml }}
+  gitops.customArgoYaml: |
+{{ .Values.main.gitops.customArgoYaml | indent 4 }}
+  {{- end }}
 
   # gitops.sourceNamespace: GitOpsDefaultCatalogSourceNamespace
   # gitops.installApprovalPlan: GitOpsDefaultApprovalPlan

--- a/tests/pattern_operator_configmap_test.yaml
+++ b/tests/pattern_operator_configmap_test.yaml
@@ -83,6 +83,25 @@ tests:
       - exists:
           path: data["gitops.argoRBAC"]
 
+  - it: Should not include gitops.customArgoYaml by default
+    asserts:
+      - notExists:
+          path: data["gitops.customArgoYaml"]
+
+  - it: Should set gitops.customArgoYaml
+    set:
+      main:
+        gitops:
+          customArgoYaml: |
+            controller:
+              resources:
+                limits:
+                  cpu: "4"
+                  memory: "16Gi"
+    asserts:
+      - exists:
+          path: data["gitops.customArgoYaml"]
+
   - it: Should set gitea parameters
     set:
       main:

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,10 @@ main:
     # -- Full ArgoCD RBAC spec as a YAML string. When set, it completely
     # overrides the default RBAC policy and additionalArgoAdmins is ignored.
     argoRBAC: ""
+    # -- Arbitrary ArgoCD .spec YAML to deep-merge into the operator-built
+    # ArgoCD CR. Allows customizing any part of the ArgoCD spec without
+    # requiring individual config keys.
+    customArgoYaml: ""
 
   # -- Settings related to the in-cluster gitea installation
   gitea:


### PR DESCRIPTION
Tested manually with
https://www.github.com/validatedpatterns/patterns-operator/pull/779 by
passing the following to values-global.yaml:

    main:
      gitops:
        customArgoYaml: |
          controller:
            resources:
              limits:
                cpu: "4"
                memory: "17Gi"

Correctly obtained the ArgoCD instance with:

    oc get -n vp-gitops argocd vp-gitops -o jsonpath='{.spec.controller.resources.limits}' | jq .
    {
      "cpu": "4",
      "memory": "17Gi"
    }
